### PR TITLE
fix(server-list): unread pill shows over user buttons

### DIFF
--- a/betterdiscord/main.css
+++ b/betterdiscord/main.css
@@ -458,7 +458,7 @@
   display: block;
   top: 0;
   left: 12px;
-  z-index: 2;
+  z-index: 1;
   width: 12px;
   height: 12px;
   background: var(--unread-color);

--- a/stuff/_server-list.scss
+++ b/stuff/_server-list.scss
@@ -1,5 +1,5 @@
 :root {
-    
+
 // Server list
 .guilds-2JjMmN .scroller-3X7KbA  {
   contain: none !important;
@@ -17,12 +17,12 @@
   .itemInner-3e_4G4 { padding: 8px;}
 }
 
-.pageWrapper-2PwDoS { 
+.pageWrapper-2PwDoS {
   background-color: var(--background-primary);
 
   .scroller-3j5xK2 { padding: 0 !important;}
 
-  .headerImage-2D5D-v { 
+  .headerImage-2D5D-v {
     position: relative;
     top: -8px;
     border-radius: 0;
@@ -35,7 +35,7 @@
 .scroller-RfJjkV {
   padding: 0 !important;
 
-  .headerImage-1c8Lrb { 
+  .headerImage-1c8Lrb {
     position: relative;
     top: -8px;
     border-radius: 0;
@@ -107,7 +107,7 @@
 .unreadMentionsIndicatorTop-2bTgUU {
   width: 100%; height: 50px;
   top: -7px; padding: 0;
-  
+
   .unreadMentionsBar-ZXXoOH {
     border-radius: 0;
     background: linear-gradient(var(--mention-color), #0000);
@@ -141,10 +141,10 @@
     &::before {
       content: "";
       position: absolute;
-      width: 16px; 
+      width: 16px;
       height: 16px;
       background-color: inherit;
-      border-radius: 100%; 
+      border-radius: 100%;
       z-index: -1;
       animation: var(--disable-animations), 2s pulse infinite;
       will-change: transform;
@@ -158,12 +158,12 @@
 .listItem-3SmSlK.unread::before,
 .wrapper-38slSD.bd-unread:not(.bd-expanded)::before,
 .wrapper-38slSD[vz-unread]:not([vz-expanded])::before,
-.wrapper-38slSD.unread:not(.expanded)::before 
+.wrapper-38slSD.unread:not(.expanded)::before
 {
   content: "";
   position: absolute;
   display: block;
-  top: 0; left: 12px; z-index: 2;
+  top: 0; left: 12px; z-index: 1;
   width: 12px; height: 12px;
   background: var(--unread-color);
   border-radius: 50%;
@@ -202,8 +202,8 @@
 .listItem-3SmSlK.bd-unread:hover .pill-2RsI5Q,
 .listItem-3SmSlK[vz-unread]:hover .pill-2RsI5Q, .listItem-3SmSlK.unread:hover .pill-2RsI5Q,
 .wrapper-38slSD.bd-unread:hover .expandedFolderBackground-1kSAf6 + .listItem-3SmSlK .pill-2RsI5Q,
-.wrapper-38slSD[vz-unread]:hover:not(.expanded) .pill-2RsI5Q, 
-.wrapper-38slSD.unread:hover:not(.expanded) .pill-2RsI5Q { 
+.wrapper-38slSD[vz-unread]:hover:not(.expanded) .pill-2RsI5Q,
+.wrapper-38slSD.unread:hover:not(.expanded) .pill-2RsI5Q {
   display: flex;
 }
 


### PR DESCRIPTION
Lower `z-index` of unread pill so that it wouldn't show over user buttons

- Before
![eu876EL4ad](https://user-images.githubusercontent.com/77577746/169813600-62015a3f-ca46-4842-916a-33b21a5ae7fb.gif)

- After
![Discord_lFH4XbzJj8](https://user-images.githubusercontent.com/77577746/169813643-6ae70f57-e88a-4f10-b903-aa61cc0af701.gif)

