### PR TITLE
Fix Unread Indicator to actually be vertically centered

### DIFF
--- a/betterdiscord/main.css
+++ b/betterdiscord/main.css
@@ -632,12 +632,14 @@
   will-change: transform;
 }
 :root .unread-36eUEm {
-  top: 54%;
+  top: 50%;
   left: 5px;
   width: 6px;
   height: 6px;
+  margin-top: 0px;
   z-index: 1;
   background-color: var(--unread-color);
+  transform: translate(0%, -50%);
   border-radius: 10px;
 }
 :root .unread-36eUEm::before {


### PR DESCRIPTION
Fixes #109 

![image](https://github.com/Comfy-Themes/Discord/assets/17491233/78512190-69e7-4227-a627-629fdf641d9a)
